### PR TITLE
Update wallet polywallet Extension type

### DIFF
--- a/packages/browser-extension-signing-manager/package.json
+++ b/packages/browser-extension-signing-manager/package.json
@@ -4,9 +4,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@polymeshassociation/signing-manager-types": "^1.0.0"
-  },
   "peerDependencies": {
     "@polymathnetwork/polymesh-sdk": ">=14.0.0"
   }

--- a/packages/browser-extension-signing-manager/src/types/index.ts
+++ b/packages/browser-extension-signing-manager/src/types/index.ts
@@ -1,19 +1,30 @@
-import { web3Enable } from '@polkadot/extension-dapp';
-import { PolkadotSigner } from '@polymeshassociation/signing-manager-types';
+import type { InjectedExtension } from '@polkadot/extension-inject/types';
 
 export type UnsubCallback = () => void;
 
+export enum NetworkName {
+  mainnet = 'mainnet',
+  testnet = 'testnet',
+  staging = 'staging',
+  local = 'local',
+}
+
 export interface NetworkInfo {
-  name: string;
+  name: NetworkName;
   label: string;
   wssUrl: string;
 }
 
-// the return value of `web3Enable` isn't properly typed. It should have a `network` property
-export type Extension = Awaited<ReturnType<typeof web3Enable>>[number] & {
+// The type of `InjectedExtension` does not include the polywallet specific `network` and `uid` properties.
+export type Extension = InjectedExtension & {
   network: {
     subscribe(cb: (networkInfo: NetworkInfo) => void): UnsubCallback;
     get(): Promise<NetworkInfo>;
   };
-  signer: PolkadotSigner;
+  uid: {
+    isSet(): Promise<boolean>;
+    provide(payload: { did: string; uid: string; network: NetworkName }): Promise<boolean>;
+    read(): Promise<{ id: number; uid: string }>;
+    requestProof(payload: { ticker: string }): Promise<{ id: number; proof: string }>;
+  };
 };


### PR DESCRIPTION
* `Extension` type was missing `uid` properties.
* The signer property was already part of `Awaited<ReturnType<typeof web3Enable>>[number]`
*  The type of `Awaited<ReturnType<typeof web3Enable>>[number]` is `InjectedExtension` already available from the `@polkadot/extension-inject/types` dependency.