### PR TITLE
docs(*): move nx attribution to bottom of README to improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Monorepo for Polymesh SDK compatible Signing Managers.
 
-This project was generated using [Nx](https://nx.dev).
-
 ## Projects
 
 | Project                               | Package                                                                                                                                      | Version                                                                                                                                                                                                       | Links                                                                                                                                                                                                                                           |
@@ -35,3 +33,7 @@ You can also use nx commands directly with `yarn nx` (i.e. `yarn nx affected --t
 ## Contributing
 
 Refer to the [Contribution Guidelines](CONTRIBUTING.md).
+
+### Info
+
+This project was generated using [Nx](https://nx.dev).

--- a/packages/approval-signing-manager/README.md
+++ b/packages/approval-signing-manager/README.md
@@ -1,7 +1,5 @@
 # approval-signing-manager
 
-This library was generated with [Nx](https://nx.dev).
-
 This signing manager was made with a specific API in which signatures for some transactions go through some kind of approval process. Some transaction may even require human approval which means the signing process may take a very long time in computer terms.
 
 This signing manager makes a request for a signature, and continues to poll until the transaction is approved.
@@ -45,3 +43,7 @@ sdk.assets.createAsset(args, { mortality: { immortal: true } });
 ## Running unit tests
 
 Run `nx test approval-signing-manager` to execute the unit tests via [Jest](https://jestjs.io).
+
+### Info
+
+This library was generated with [Nx](https://nx.dev).

--- a/packages/browser-extension-signing-manager/README.md
+++ b/packages/browser-extension-signing-manager/README.md
@@ -2,8 +2,6 @@
 
 Polymesh SDK (14+) compatible signing manager that manages accounts and signs via a polkadot compatible browser wallet extension.
 
-This library was generated with [Nx](https://nx.dev).
-
 ## Usage
 
 ```typescript
@@ -31,3 +29,7 @@ signingManager.onNetworkChange(newNetwork => {
   // act accordingly
 });
 ```
+
+### Info
+
+This library was generated with [Nx](https://nx.dev).

--- a/packages/hashicorp-vault-signing-manager/README.md
+++ b/packages/hashicorp-vault-signing-manager/README.md
@@ -2,8 +2,6 @@
 
 Polymesh SDK (v14+) compatible signing manager that interacts with a Hashicorp Vault for signing.
 
-This library was generated with [Nx](https://nx.dev).
-
 ## Usage
 
 ```typescript
@@ -23,3 +21,7 @@ const sdk = await Polymesh.connect({
   signingManager,
 });
 ```
+
+### Info
+
+This library was generated with [Nx](https://nx.dev).

--- a/packages/local-signing-manager/README.md
+++ b/packages/local-signing-manager/README.md
@@ -2,8 +2,6 @@
 
 Polymesh SDK (v14+) compatible signing manager that stores private keys in memory.
 
-This library was generated with [Nx](https://nx.dev).
-
 ## Usage
 
 ```typescript
@@ -24,3 +22,7 @@ const sdk = await Polymesh.connect({
   signingManager,
 });
 ```
+
+### Info
+
+This library was generated with [Nx](https://nx.dev).

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -2,4 +2,6 @@
 
 Base types for Signing Managers
 
+### Info
+
 This library was generated with [Nx](https://nx.dev).


### PR DESCRIPTION
### Description

Its distracting to see the "made with nx" link at the top of the npm page or the Slack widget.

### Breaking Changes

None

### JIRA Link

N/A

### Checklist

- [X] Updated the Readme.md (if required) ?
