### PR TITLE
fix(hashicorp-vault-signing-manager): fetchAllKeys returns empty list

### DIFF
--- a/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault/hashicorp-vault.spec.ts
+++ b/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault/hashicorp-vault.spec.ts
@@ -79,6 +79,19 @@ describe('HashicorpVault class', () => {
       expect(result).toEqual(expectedKeys);
     });
 
+    it('should return an empty list when Vault returns 404', async () => {
+      // https://github.com/hashicorp/vault/issues/1365#issuecomment-216369253
+      fetchStub.mockResolvedValueOnce(
+        createMockResponse(404, 'Not Found', {
+          errors: [],
+        })
+      );
+
+      const result = await vault.fetchAllKeys();
+
+      expect(result).toEqual([]);
+    });
+
     it('should throw any errors returned by the Vault API', () => {
       fetchStub.mockResolvedValue(
         createMockResponse(400, 'Bad Request', {

--- a/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault/hashicorp-vault.ts
+++ b/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault/hashicorp-vault.ts
@@ -42,6 +42,11 @@ export class HashicorpVault {
       headers,
     });
 
+    // Vault returns 404 for empty lists for [ease of implementation](https://github.com/hashicorp/vault/issues/1365#issuecomment-216369253)
+    if (response.status === 404) {
+      return [];
+    }
+
     await this.assertResponseOk(response);
 
     const {


### PR DESCRIPTION
### Description

Previously at least one key must be present in Vault or else fetchAllKeys would throw

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
