### PR TITLE
fix(*): use shared signed extensions to prevent StoreCallMetadata warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Monorepo for Polymesh SDK compatible Signing Managers.
 If using on a unix type computer, all packages can be built (or test/lint) with:
 
 ```sh
-ls packages | cut -d "_" -f 1 | xargs -I {} bash -c "yarn build} {}"
+ls packages | cut -d "_" -f 1 | xargs -I {} bash -c "yarn build {}"
 ```
 
 ### Manual Testing

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Monorepo for Polymesh SDK compatible Signing Managers.
 - Testing: `yarn test <packageName>`
 - Building: `yarn build <packageName>`
 
+If using on a unix type computer, all packages can be built (or test/lint) with:
+
+```sh
+ls packages | cut -d "_" -f 1 | xargs -I {} bash -c "yarn build} {}"
+```
+
 ### Manual Testing
 
 In order to test your code manually before releasing:

--- a/packages/approval-signing-manager/src/lib/approval-signing-manager.ts
+++ b/packages/approval-signing-manager/src/lib/approval-signing-manager.ts
@@ -2,7 +2,11 @@ import { TypeRegistry } from '@polkadot/types';
 import { SignerPayloadJSON, SignerPayloadRaw, SignerResult } from '@polkadot/types/types';
 import { hexToU8a } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';
-import { PolkadotSigner, SigningManager } from '@polymeshassociation/signing-manager-types';
+import {
+  PolkadotSigner,
+  signedExtensions,
+  SigningManager,
+} from '@polymeshassociation/signing-manager-types';
 
 import { ApprovalClient } from './approval-client/approval-client';
 import { KeyRecordWithOwner } from './approval-client/types';
@@ -26,9 +30,7 @@ export class ApprovalSigner implements PolkadotSigner {
    */
   public async signPayload(payload: SignerPayloadJSON): Promise<SignerResult> {
     const { registry } = this;
-    const { address, signedExtensions, version } = payload;
-
-    registry.setSignedExtensions(signedExtensions);
+    const { address, version } = payload;
 
     const signablePayload = registry.createType('ExtrinsicPayload', payload, {
       version,
@@ -115,8 +117,11 @@ export class ApprovalSigningManager implements SigningManager {
   }) {
     const { url, apiClientId, apiKey, pollingInterval = 15 } = args;
 
+    const registry = new TypeRegistry();
+    registry.setSignedExtensions(signedExtensions);
+
     this.approvalClient = new ApprovalClient(url, apiClientId, apiKey, pollingInterval);
-    this.externalSigner = new ApprovalSigner(this.approvalClient, new TypeRegistry());
+    this.externalSigner = new ApprovalSigner(this.approvalClient, registry);
   }
 
   /**

--- a/packages/local-signing-manager/src/lib/local-signing-manager.spec.ts
+++ b/packages/local-signing-manager/src/lib/local-signing-manager.spec.ts
@@ -3,6 +3,7 @@ import { TypeRegistry } from '@polkadot/types';
 import { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import { hexToU8a, stringToU8a, u8aToHex } from '@polkadot/util';
 import { cryptoWaitReady, mnemonicGenerate, signatureVerify } from '@polkadot/util-crypto';
+import { signedExtensions } from '@polymeshassociation/signing-manager-types';
 
 import { PrivateKey } from '../types';
 import { KeyringSigner, LocalSigningManager } from './local-signing-manager';
@@ -129,6 +130,7 @@ describe('class KeyringSigner', () => {
 
   beforeEach(() => {
     registry = new TypeRegistry();
+    registry.setSignedExtensions(signedExtensions);
     signer = new KeyringSigner(keyring, registry);
   });
 

--- a/packages/local-signing-manager/src/lib/local-signing-manager.ts
+++ b/packages/local-signing-manager/src/lib/local-signing-manager.ts
@@ -8,7 +8,11 @@ import {
 } from '@polkadot/types/types';
 import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { cryptoWaitReady, mnemonicGenerate } from '@polkadot/util-crypto';
-import { PolkadotSigner, SigningManager } from '@polymeshassociation/signing-manager-types';
+import {
+  PolkadotSigner,
+  signedExtensions,
+  SigningManager,
+} from '@polymeshassociation/signing-manager-types';
 
 import { PrivateKey } from '../types';
 
@@ -28,11 +32,9 @@ export class KeyringSigner implements PolkadotSigner {
    */
   public async signPayload(payload: SignerPayloadJSON): Promise<SignerResult> {
     const { registry } = this;
-    const { address, signedExtensions, version } = payload;
+    const { address, version } = payload;
 
     const pair = this.getPair(address);
-
-    registry.setSignedExtensions(signedExtensions);
 
     const signablePayload = registry.createType('ExtrinsicPayload', payload, {
       version,
@@ -124,7 +126,10 @@ export class LocalSigningManager implements SigningManager {
       type: 'sr25519',
     });
 
-    this.externalSigner = new KeyringSigner(this.keyring, new TypeRegistry());
+    const registry = new TypeRegistry();
+    registry.setSignedExtensions(signedExtensions);
+
+    this.externalSigner = new KeyringSigner(this.keyring, registry);
 
     accounts.forEach(account => {
       this._addAccount(account);


### PR DESCRIPTION
### Description

Prevents a warning from being logged by registering shared signed extensions

### Breaking Changes

None

### JIRA Link

[DA-482](https://polymesh.atlassian.net/browse/DA-482)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-482]: https://polymesh.atlassian.net/browse/DA-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ