### PR TITLE
fix(*): main field in package.json to reference index.js correctly

### DIFF
--- a/packages/approval-signing-manager/package.json
+++ b/packages/approval-signing-manager/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@polymeshassociation/approval-signing-manager",
   "version": "1.0.5",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PolymeshAssociation/signing-managers.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/browser-extension-signing-manager/package.json
+++ b/packages/browser-extension-signing-manager/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@polymeshassociation/browser-extension-signing-manager",
   "version": "1.1.3",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PolymeshAssociation/signing-managers.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fireblocks-signing-manager/package.json
+++ b/packages/fireblocks-signing-manager/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@polymeshassociation/fireblocks-signing-manager",
   "version": "1.0.3",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PolymeshAssociation/signing-managers.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/hashicorp-vault-signing-manager/package.json
+++ b/packages/hashicorp-vault-signing-manager/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@polymeshassociation/hashicorp-vault-signing-manager",
   "version": "1.1.6",
+  "main": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PolymeshAssociation/signing-managers.git"
+  },
+  "typings": "./index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/local-signing-manager/package.json
+++ b/packages/local-signing-manager/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@polymeshassociation/local-signing-manager",
   "version": "1.4.1",
+  "main": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PolymeshAssociation/signing-managers.git"
+  },
+  "typings": "./index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/local-signing-manager/project.json
+++ b/packages/local-signing-manager/project.json
@@ -41,7 +41,7 @@
     "run-local": {
       "executor": "./tools/executors/run-local:run-local",
       "options": {
-        "runInBrowser": false,        
+        "runInBrowser": false,
         "path": "packages/local-signing-manager/sandbox/index.ts",
         "port": 9000
       }

--- a/packages/local-signing-manager/src/lib/local-signing-manager.spec.ts
+++ b/packages/local-signing-manager/src/lib/local-signing-manager.spec.ts
@@ -54,6 +54,7 @@ describe('LocalSigningManager Class', () => {
 
   describe('method: create', () => {
     it('should default to sr25519 key ring type', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const exposedManager = signingManager as any;
 
       expect(exposedManager.keyring.type).toEqual('sr25519');
@@ -63,6 +64,7 @@ describe('LocalSigningManager Class', () => {
       const ed25519Manager = (await LocalSigningManager.create({
         accounts: [],
         type: 'ed25519',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       })) as any;
 
       expect(ed25519Manager.keyring.type).toEqual('ed25519');

--- a/tools/generators/signing-manager/index.ts
+++ b/tools/generators/signing-manager/index.ts
@@ -36,6 +36,13 @@ export default async function (tree: Tree, schema: Schema) {
       '@polymeshassociation/polymesh-sdk': '>=15.0.0',
     };
 
+    contents.main = './index.js';
+    contents.typings = './index.d.ts';
+    contents.repository = {
+      type: 'git',
+      url: 'https://github.com/PolymeshAssociation/signing-managers.git',
+    };
+
     return contents;
   });
 


### PR DESCRIPTION
### Description

By adding main in the projects package.json, nx will use the proper reference in final package, while looking at src when developing.

I noticed the earning come up when I was trying various build things, so I figured I should fix this.

I also added a repository reference as seen here. I looked at a polkadot package for the format. I saw lib grading tool dock marks for not having it. Probably something we should add in other repos as well.

### Breaking Changes

None

### JIRA Link

[DA-547](https://polymesh.atlassian.net/browse/DA-547)

### Checklist

- [ ] Updated the Readme.md (if required) ?
