### PR TITLE
fix(types): update types package.json main field

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,5 +3,7 @@
   "version": "1.2.3",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "main": "./index.js",
+  "typings": "./index.d.ts"
 }


### PR DESCRIPTION
### Description

fixes a warning of "invalid main" with newer node versions. I missed this when I was fixing the other repos. I assumed a types repo wouldn't have a "main", but node v18 does warn about this.

### Breaking Changes

None

### JIRA Link

n/a

### Checklist

- [ ] Updated the Readme.md (if required) ?
