### PR TITLE
feat(fireblocks-signing-manager): allow secret to passed directly

### DIFF
--- a/packages/fireblocks-signing-manager/README.md
+++ b/packages/fireblocks-signing-manager/README.md
@@ -4,7 +4,7 @@ Polymesh SDK (v14+) compatible signing manager that interacts with [Fireblocks](
 
 ## Usage
 
-You will need a Fireblocks Account and setup access for the API. This involves generating an API Key as well as a secret file to authenticate with.
+You will need a Fireblocks Account and setup access for the API. This involves generating an API Key as well as a secret to authenticate with.
 
 Also, you will need to ask for Fireblocks to enable "raw signing" for your account. You should understand the risks and why raw signing is not enabled by default.
 
@@ -18,7 +18,7 @@ Note these derived keys will need to join as a Secondary key, or have a CDD clai
 const signingManager = await FireblocksSigningManager.create({
   url: 'https://api.fireblocks.io',
   apiToken: 'API_TOKEN',
-  secretPath: './path/to/secret.key',
+  secret: 'abc...',
   derivationPaths: [[44, 595, 0, 0, 0]], // derive mainnet key with the "default" Fireblocks account
 });
 

--- a/packages/fireblocks-signing-manager/src/lib/fireblocks-signing-manager.spec.ts
+++ b/packages/fireblocks-signing-manager/src/lib/fireblocks-signing-manager.spec.ts
@@ -36,7 +36,7 @@ const fireblocksKeys: PublicKeyResonse[] = [
 
 const url = 'http://example.com';
 const apiKey = 'API-KEY';
-const secretPath = './secret.key';
+const secret = 'someSecret';
 const ss58Format = 42;
 
 describe('FireblocksSigningManager Class', () => {
@@ -46,7 +46,7 @@ describe('FireblocksSigningManager Class', () => {
     signingManager = await FireblocksSigningManager.create({
       url,
       apiKey,
-      secretPath,
+      secret,
       derivationPaths: [],
     });
 
@@ -58,7 +58,7 @@ describe('FireblocksSigningManager Class', () => {
       const manager = await FireblocksSigningManager.create({
         url,
         apiKey,
-        secretPath,
+        secret,
         derivationPaths: [],
       });
 
@@ -78,7 +78,7 @@ describe('FireblocksSigningManager Class', () => {
         FireblocksSigningManager.create({
           url,
           apiKey,
-          secretPath,
+          secret,
           derivationPaths,
         })
       ).rejects.toThrow(expectedError);
@@ -122,7 +122,7 @@ describe('FireblocksSigningManager Class', () => {
     let fireblocks: Fireblocks;
 
     beforeEach(() => {
-      fireblocks = new Fireblocks({ url, apiKey, secretPath });
+      fireblocks = new Fireblocks({ url, apiKey, secret });
       registry = new TypeRegistry();
       signer = new FireblocksSigner(fireblocks, registry);
     });

--- a/packages/fireblocks-signing-manager/src/lib/fireblocks-signing-manager.ts
+++ b/packages/fireblocks-signing-manager/src/lib/fireblocks-signing-manager.ts
@@ -100,12 +100,12 @@ export class FireblocksSigningManager implements SigningManager {
    * @hidden
    */
   private constructor(args: Omit<CreateParams, 'derivationPaths'>) {
-    const { url, apiKey, secretPath } = args;
+    const { url, apiKey, secret } = args;
 
     const registry = new TypeRegistry();
     registry.setSignedExtensions(signedExtensions);
 
-    this.fireblocksClient = new Fireblocks({ url, apiKey, secretPath });
+    this.fireblocksClient = new Fireblocks({ url, apiKey, secret });
     this.externalSigner = new FireblocksSigner(this.fireblocksClient, registry);
   }
 

--- a/packages/fireblocks-signing-manager/src/lib/fireblocks/fireblocks.spec.ts
+++ b/packages/fireblocks-signing-manager/src/lib/fireblocks/fireblocks.spec.ts
@@ -10,7 +10,7 @@ jest.mock('fs');
 describe('Fireblocks class', () => {
   const url = 'http://example.com';
   const apiKey = 'someToken';
-  const secretPath = './some-secret.key';
+  const secret = 'someSecret';
 
   const defaultKey = {
     status: 0,
@@ -34,7 +34,7 @@ describe('Fireblocks class', () => {
   let fireblocks: Fireblocks;
 
   beforeEach(() => {
-    fireblocks = new Fireblocks({ url, apiKey, secretPath });
+    fireblocks = new Fireblocks({ url, apiKey, secret });
   });
 
   describe('method: fetchAllKeys', () => {

--- a/packages/fireblocks-signing-manager/src/lib/fireblocks/fireblocks.ts
+++ b/packages/fireblocks-signing-manager/src/lib/fireblocks/fireblocks.ts
@@ -8,7 +8,6 @@ import {
   TransactionResponse,
   TransactionStatus,
 } from 'fireblocks-sdk';
-import { readFileSync } from 'fs';
 
 import { DerivationPath, KeyInfo, NoTransactionSignature } from './types';
 
@@ -21,10 +20,8 @@ export class Fireblocks {
   public fireblocksSdk: FireblocksSDK;
   private addressBook: Record<HexString, PublicKeyResonse> = {};
 
-  public constructor(args: { url: string; apiKey: string; secretPath: string }) {
-    const { secretPath, apiKey, url } = args;
-
-    const secret = readFileSync(secretPath, 'utf8');
+  public constructor(args: { url: string; apiKey: string; secret: string }) {
+    const { secret, apiKey, url } = args;
 
     this.fireblocksSdk = new FireblocksSDK(secret, apiKey, url);
   }

--- a/packages/fireblocks-signing-manager/src/lib/fireblocks/types.ts
+++ b/packages/fireblocks-signing-manager/src/lib/fireblocks/types.ts
@@ -27,9 +27,9 @@ export interface CreateParams {
    */
   apiKey: string;
   /**
-   * Path to a file containing the secret file for interacting with the Fireblocks API
+   * An account secret necessary to authenticate with the Fireblocks API
    */
-  secretPath: string;
+  secret: string;
   /**
    * (optional) Derivation paths to initialize Accounts upon creation. Accounts can also be added dynamically by calling `deriveAccount` on the signing manager
    */


### PR DESCRIPTION
### Description

initalizes fireblocks by accepting a secret param directly. previously a file path would need to be given, which would be read in the contructor. this allows for more flexible secret storage


### Breaking Changes

BREAKING CHANGE: `secretPath` is now `secret`. To maintain old behavior use `fs.readFileSync` and pass the secret to the constructor instead of the path

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
