### PR TITLE
Ignore non ed25519

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@polkadot/util": "^12.4.2",
     "@polkadot/util-crypto": "^12.4.2",
     "cross-fetch": "^3.1.5",
-    "lodash": "^4.17.21",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
@@ -46,7 +45,6 @@
     "@nrwl/workspace": "13.8.2",
     "@open-wc/webpack-import-meta-loader": "^0.4.7",
     "@types/jest": "27.0.2",
-    "@types/lodash": "^4.14.179",
     "@types/node": "16.11.7",
     "@types/require-from-string": "^1.2.1",
     "@typescript-eslint/eslint-plugin": "~5.10.0",

--- a/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault/hashicorp-vault.spec.ts
+++ b/packages/hashicorp-vault-signing-manager/src/lib/hashicorp-vault/hashicorp-vault.spec.ts
@@ -53,9 +53,11 @@ describe('HashicorpVault class', () => {
               keys: {
                 '1': {
                   public_key: 'cqWlP2oERZqOjtJmzASNt/jI0/qsAgT5ntWTQAutY2w=',
+                  name: 'ed25519',
                 },
                 '2': {
                   public_key: '7CYkynab5bxXzSPw8djAag9orAalfgA1U2HUUACvfCg=',
+                  name: 'ed25519',
                 },
               },
             },
@@ -67,6 +69,7 @@ describe('HashicorpVault class', () => {
               keys: {
                 '1': {
                   public_key: 'GvM3BzqsB8JiK6OThUhQNBz/ES1dY4De8j7jI7DUiAI=',
+                  name: 'ed25519',
                 },
               },
             },
@@ -114,9 +117,11 @@ describe('HashicorpVault class', () => {
               /* eslint-disable @typescript-eslint/naming-convention */
               '1': {
                 public_key: 'cqWlP2oERZqOjtJmzASNt/jI0/qsAgT5ntWTQAutY2w=',
+                name: 'ed25519',
               },
               '2': {
                 public_key: '7CYkynab5bxXzSPw8djAag9orAalfgA1U2HUUACvfCg=',
+                name: 'ed25519',
               },
               /* eslint-enable @typescript-eslint/naming-convention */
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3258,11 +3258,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.179":
-  version "4.14.179"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
-  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
-
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"


### PR DESCRIPTION
### Description

Prevents hashicorp vault from crashing when non ed25519 keys are present in the connected transit engine.

### Breaking Changes

None

### JIRA Link

[DA-1103](https://polymesh.atlassian.net/browse/DA-1103)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1103]: https://polymesh.atlassian.net/browse/DA-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ