### PR TITLE
chore(*): set "git" to false in release config

### DIFF
--- a/packages/approval-signing-manager/project.json
+++ b/packages/approval-signing-manager/project.json
@@ -46,6 +46,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/approval-signing-manager@${version}",
         "branches": [
           { "name": "main" },

--- a/packages/azure-signing-manager/project.json
+++ b/packages/azure-signing-manager/project.json
@@ -46,6 +46,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/azure-signing-manager@${version}",
         "branches": [
           { "name": "main" },

--- a/packages/browser-extension-signing-manager/project.json
+++ b/packages/browser-extension-signing-manager/project.json
@@ -46,6 +46,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/browser-signing-manager@${version}",
         "branches": [
           { "name": "main" },

--- a/packages/fireblocks-signing-manager/project.json
+++ b/packages/fireblocks-signing-manager/project.json
@@ -46,6 +46,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/fireblocks-signing-manager@${version}",
         "branches": [
           { "name": "main" },

--- a/packages/hashicorp-vault-signing-manager/project.json
+++ b/packages/hashicorp-vault-signing-manager/project.json
@@ -46,6 +46,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/hashicorp-signing-manager@${version}",
         "branches": [
           { "name": "main" },

--- a/packages/local-signing-manager/project.json
+++ b/packages/local-signing-manager/project.json
@@ -45,6 +45,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/local-signing-manager@${version}",
         "branches": [
           { "name": "main" },

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -46,6 +46,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/signing-manager-types@${version}",
         "branches": [
           { "name": "main" },

--- a/packages/walletconnect-signing-manager/project.json
+++ b/packages/walletconnect-signing-manager/project.json
@@ -46,6 +46,7 @@
         "github": true,
         "changelog": true,
         "npm": true,
+        "git": false,
         "tagFormat": "@polymeshassociation/walletconnect-signing-manager@${version}",
         "branches": [
           { "name": "main" },


### PR DESCRIPTION
### Description

By default a commit is made with the plugin: https://github.com/TheUnderScorer/nx-semantic-release?tab=readme-ov-file#available-options

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
