### PR TITLE
chore(*): enable verbose publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn --frozen-lockfile
       - name: build and release
         run: |
-         yarn nx run @polymeshassociation/azure-signing-manager:semantic-release
+         yarn nx run @polymeshassociation/azure-signing-manager:semantic-release --verbose
         # TODO use: yarn nx run-many --all --target=semantic-release --parallel=false
 
         env:


### PR DESCRIPTION
### Description

Last error said to run with verbose: https://github.com/PolymeshAssociation/signing-managers/actions/runs/11279819918/job/31371451179#step:6:70

I am not sure why the error only appears on the runner. Standard runners have 16GB of RAM + 4 CPU, so its not like they are under powered: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
